### PR TITLE
send signature as b58 string to avoid "invalid UTF-8 string" error

### DIFF
--- a/multipro/main.go
+++ b/multipro/main.go
@@ -41,7 +41,7 @@ func main() {
 	h1.Peerstore().AddAddrs(h2.ID(), h2.Addrs(), ps.PermanentAddrTTL)
 	h2.Peerstore().AddAddrs(h1.ID(), h1.Addrs(), ps.PermanentAddrTTL)
 
-	log.Printf("This is a conversation between %s and %s\n", h1.ID(), h2.ID())
+	log.Printf("This is a conversation between %s and %s\n", h1.ID().Pretty(), h2.ID().Pretty())
 
 	// send messages using the protocols
 	h1.Ping(h2.Host)

--- a/multipro/node.go
+++ b/multipro/node.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	crypto "github.com/libp2p/go-libp2p-crypto"
+	p2p "github.com/libp2p/go-libp2p-examples/multipro/pb"
 	host "github.com/libp2p/go-libp2p-host"
 	inet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
-	p2p "github.com/libp2p/go-libp2p-examples/multipro/pb"
+	b58 "github.com/mr-tron/base58/base58"
 	protobufCodec "github.com/multiformats/go-multicodec/protobuf"
 )
 
@@ -59,9 +60,16 @@ func (n *Node) authenticateMessage(message proto.Message, data *p2p.MessageData)
 		return false
 	}
 
+	// restore signature binary format from base58 encoded string
+	sigBytes, err := b58.Decode(sign)
+	if err != nil {
+		log.Println(err, "Failed to decode signature from base58")
+		return false
+	}
+
 	// verify the data was authored by the signing peer identified by the public key
 	// and signature included in the message
-	return n.verifyData(bin, []byte(sign), peerId, data.NodePubKey)
+	return n.verifyData(bin, sigBytes, peerId, data.NodePubKey)
 }
 
 // sign an outgoing p2p message payload


### PR DESCRIPTION
Trying to run the "multipro" example, I was receiving an "invalid UTF-8 string" error. I turned out that the message encoder did not like the signature cast directly to string with `string(signature)`. When I changed to encode/decode as base 58 string with the github.com/mr-tron/base58/base58 library, it worked fine.

I also changed all the log messages to output the full node ID instead of the first 6 characters. The first 6 characters were always the same, so not useful in showing what was really happening.