### PR TITLE
doc: update build section of READMEs and remove misleading comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,21 @@ Let us know if you find any issue or if you want to contribute and add a new tut
 - [Multicodecs with protobufs](./multipro)
 - [P2P chat application](./chat)
 - [P2P chat application w/ rendezvous peer discovery](./chat-with-rendezvous)
+
+## Troubleshooting
+
+When building the examples ensure you have a clean `$GOPATH`. If you have checked out and built other `libp2p` repos then you may get errors similar to the one below when building the examples. Note that the use of the `gx` package manager **is not required** to run the examples or to use `libp2p`.
+```
+$:~/go/src/github.com/libp2p/go-libp2p-examples/libp2p-host$ go build host.go 
+# command-line-arguments
+./host.go:36:18: cannot use priv (type "github.com/libp2p/go-libp2p-crypto".PrivKey) as type "gx/ipfs/QmNiJiXwWE3kRhZrC5ej3kSjWHm337pYfhjLGSCDNKJP2s/go-libp2p-crypto".PrivKey in argument to libp2p.Identity:
+        "github.com/libp2p/go-libp2p-crypto".PrivKey does not implement "gx/ipfs/QmNiJiXwWE3kRhZrC5ej3kSjWHm337pYfhjLGSCDNKJP2s/go-libp2p-crypto".PrivKey (wrong type for Equals method)
+                have Equals("github.com/libp2p/go-libp2p-crypto".Key) bool
+                want Equals("gx/ipfs/QmNiJiXwWE3kRhZrC5ej3kSjWHm337pYfhjLGSCDNKJP2s/go-libp2p-crypto".Key) bool
+```
+
+To obtain a clean `$GOPATH` execute the following:
+```
+> mkdir /tmp/libp2p-examples
+> export $GOPATH=/tmp/libp2p/examples
+```

--- a/chat-with-rendezvous/README.md
+++ b/chat-with-rendezvous/README.md
@@ -1,13 +1,15 @@
-# p2p chat app with libp2p [support peer discovery]
+# p2p chat app with libp2p [with peer discovery]
 
-This program demonstrates a simple p2p chat application. You will learn how to discover a peer in the network (using kad-dht), connect to it and open a chat stream. 
+This program demonstrates a simple p2p chat application. You will learn how to discover a peer in the network (using kad-dht), connect to it and open a chat stream.
 
-## How to build this example?
+## Build
+
+From the `go-libp2p-examples` directory run the following:
 
 ```
-go get github.com/libp2p/go-libp2p-examples/chat-with-rendezvous
-
-go build *.go
+> make deps
+> cd chat-with-rendezvous/
+> go build -o chat
 ```
 
 ## Usage
@@ -28,17 +30,17 @@ ctx := context.Background()
 // Other options can be added here.
 host, err := libp2p.New(ctx)
 ```
-[libp2p.New](https://godoc.org/github.com/libp2p/go-libp2p#New) is the constructor for libp2p node. It creates a host with given configuration. Right now, all the options are default, documented [here](https://godoc.org/github.com/libp2p/go-libp2p#New)
+[libp2p.New](https://godoc.org/github.com/libp2p/go-libp2p#New) is the constructor for a libp2p node. It creates a host with the given configuration. Right now, all the options are default, documented [here](https://godoc.org/github.com/libp2p/go-libp2p#New)
 
 2. **Set a default handler function for incoming connections.**
 
-This function is called on the local peer when a remote peer initiate a connection and starts a stream with the local peer.
+This function is called on the local peer when a remote peer initiates a connection and starts a stream with the local peer.
 ```go
 // Set a function as stream handler.
 host.SetStreamHandler("/chat/1.1.0", handleStream)
 ```
 
-```handleStream``` is executed for each new stream incoming to the local peer. ```stream``` is used to exchange data between local and remote peer. This example uses non blocking functions for reading and writing from this stream.
+```handleStream``` is executed for each new incoming stream to the local peer. ```stream``` is used to exchange data between the local and remote peers. This example uses non blocking functions for reading and writing from this stream.
 
 ```go
 func handleStream(stream net.Stream) {
@@ -81,14 +83,14 @@ for _, addr := range bootstrapPeers {
 
 5. **Announce your presence using a rendezvous point.**
 
-[routingDiscovery.Advertise](https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery.Advertise) makes this node announce that it can provide a value for the given key. Where a key in this case is ```rendezvousString```. Other peers will hit the same key to find other peers. 
+[routingDiscovery.Advertise](https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery.Advertise) makes this node announce that it can provide a value for the given key. Where a key in this case is ```rendezvousString```. Other peers will hit the same key to find other peers.
 
 ```go
 routingDiscovery := discovery.NewRoutingDiscovery(kademliaDHT)
 discovery.Advertise(ctx, routingDiscovery, config.RendezvousString)
 ```
 
-6. **Find peers nearby.**
+6. **Find nearby peers.**
 
 [routingDiscovery.FindPeers](https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery.FindPeers) will return a channel of peers who have announced their presence.
 
@@ -100,9 +102,9 @@ The [discovery](https://godoc.org/github.com/libp2p/go-libp2p-discovery#pkg-inde
 
 **Note:** Although [routingDiscovery.Advertise](https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery.Advertise) and [routingDiscovery.FindPeers](https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery.FindPeers) works for a rendezvous peer discovery, this is not the right way of doing it. Libp2p is currently working on an actual rendezvous protocol ([libp2p/specs#56](https://github.com/libp2p/specs/pull/56)) which can be used for bootstrap purposes, real time peer discovery and application specific routing.
 
-7. **Open streams to peers found.**
+7. **Open streams to newly discovered peers.**
 
-Finally we open stream to the peers we found, as we find them
+Finally we open streams to the newly discovered peers.
 
 ```go
 go func() {

--- a/chat/README.md
+++ b/chat/README.md
@@ -1,7 +1,7 @@
 # p2p chat app with libp2p
 
 This program demonstrates a simple p2p chat application. It can work between two peers if
-1. Both have private IP address (same network).
+1. Both have a private IP address (same network).
 2. At least one of them has a public IP address.
 
 Assume if 'A' and 'B' are on different networks host 'A' may or may not have a public IP address but host 'B' has one.
@@ -10,11 +10,12 @@ Usage: Run `./chat -sp <SOURCE_PORT>` on host 'B' where <SOURCE_PORT> can be any
 
 ## Build
 
-From `go-libp2p-examples` base folder:
+From the `go-libp2p-examples` directory run the following:
 
 ```
 > make deps
-> go build ./chat
+> cd chat
+> go build
 ```
 
 ## Usage
@@ -43,7 +44,7 @@ This node's multiaddress:
 > hello
 ```
 
-**NOTE: debug mode is enabled by default, debug mode will always generate same node id (on each node) on every execution. Disable debug using `--debug false` flag while running your executable.**
+**NOTE: debug mode is enabled by default, debug mode will always generate the same node id (on each node) on every execution. Disable debug using `--debug false` flag while running your executable.**
 
 **Note:** If you are looking for an implementation with peer discovery, [chat-with-rendezvous](../chat-with-rendezvous), supports peer discovery using a rendezvous point.
 

--- a/echo/README.md
+++ b/echo/README.md
@@ -10,11 +10,12 @@ In dial mode, the node will start up, connect to the given address, open a strea
 
 ## Build
 
-From `go-libp2p-examples` base folder:
+From the `go-libp2p-examples` directory run the following:
 
 ```
 > make deps
-> go build ./echo
+> cd echo/
+> go build
 ```
 
 ## Usage
@@ -44,9 +45,9 @@ In order to create the swarm (and a `basichost`), the example needs:
 
 - An [ipfs-procotol ID](https://godoc.org/github.com/libp2p/go-libp2p-peer#ID) like `QmNtX1cvrm2K6mQmMEaMxAuB4rTexhd87vpYVot4sEZzxc`. The example autogenerates a key pair on every run and uses an ID extracted from the public key (the hash of the public key). When using `-secio`, it uses the key pair to encrypt communications (otherwise, it leaves the connections unencrypted).
 - A [Multiaddress](https://godoc.org/github.com/multiformats/go-multiaddr), which indicates how to reach this peer. There can be several of them (using different protocols or locations for example). Example: `/ip4/127.0.0.1/tcp/1234`.
-- A [go-libp2p-peerstore](https://godoc.org/github.com/libp2p/go-libp2p-peerstore), which is used as a address book which matches node IDs to the multiaddresses through which they can be contacted. This peerstore gets autopopulated when manually opening a connection (with [`Connect()`](https://godoc.org/github.com/libp2p/go-libp2p/p2p/host/basic#BasicHost.Connect). Alternatively, we can manually [`AddAddr()`](https://godoc.org/github.com/libp2p/go-libp2p-peerstore#AddrManager.AddAddr) as in the example.
+- A [go-libp2p-peerstore](https://godoc.org/github.com/libp2p/go-libp2p-peerstore), which is used as an address book which matches node IDs to the multiaddresses through which they can be contacted. This peerstore gets autopopulated when manually opening a connection (with [`Connect()`](https://godoc.org/github.com/libp2p/go-libp2p/p2p/host/basic#BasicHost.Connect). Alternatively, we can manually [`AddAddr()`](https://godoc.org/github.com/libp2p/go-libp2p-peerstore#AddrManager.AddAddr) as in the example.
 
-A `basichost` can now open streams (bi-directional channel between to peers) using [NewStream](https://godoc.org/github.com/libp2p/go-libp2p/p2p/host/basic#BasicHost.NewStream) and use them to send and receive data tagged with a `Protocol.ID` (a string). The host can also listen for incoming connections for a given
+A `basichost` can now open streams (bi-directional channel between two peers) using [NewStream](https://godoc.org/github.com/libp2p/go-libp2p/p2p/host/basic#BasicHost.NewStream) and use them to send and receive data tagged with a `Protocol.ID` (a string). The host can also listen for incoming connections for a given
 `Protocol` with [`SetStreamHandle()`](https://godoc.org/github.com/libp2p/go-libp2p/p2p/host/basic#BasicHost.SetStreamHandler).
 
 The example makes use of all of this to enable communication between a listener and a sender using protocol `/echo/1.0.0` (which could be any other thing).

--- a/http-proxy/README.md
+++ b/http-proxy/README.md
@@ -1,6 +1,6 @@
 # HTTP proxy service with libp2p
 
-This examples shows how to create a simple HTTP proxy service with libp2p:
+This example shows how to create a simple HTTP proxy service with libp2p:
 
 ```
                                                                                                     XXX
@@ -22,11 +22,12 @@ Note that this is a very simple approach to a proxy, and does not perform any he
 
 ## Build
 
-From `go-libp2p-examples` base folder:
+From the `go-libp2p-examples` directory run the following:
 
 ```
 > make deps
-> go build ./http-proxy
+> cd http-proxy/
+> go build
 ```
 
 ## Usage
@@ -40,7 +41,7 @@ libp2p-peer addresses:
 /ip4/127.0.0.1/tcp/12000/ipfs/QmddTrQXhA9AkCpXPTkcY7e22NK73TwkUms3a44DhTKJTD
 ```
 
-The run the local peer, indicating that it will need to forward http requests to the remote peer as follows:
+Then run the local peer, indicating that it will need to forward http requests to the remote peer as follows:
 
 ```
 > ./http-proxy -d /ip4/127.0.0.1/tcp/12000/ipfs/QmddTrQXhA9AkCpXPTkcY7e22NK73TwkUms3a44DhTKJTD
@@ -50,7 +51,7 @@ libp2p-peer addresses:
 proxy listening on  127.0.0.1:9900
 ```
 
-As you can see, the proxy prints the listening address `127.0.0.1:9900`. You can now use this address as proxy, for example with `curl`:
+As you can see, the proxy prints the listening address `127.0.0.1:9900`. You can now use this address as a proxy, for example with `curl`:
 
 ```
 > curl -x "127.0.0.1:9900" "http://ipfs.io/ipfs/QmfUX75pGRBRDnjeoMkQzuQczuCup2aYbeLxz5NzeSu9G6"

--- a/http-proxy/proxy.go
+++ b/http-proxy/proxy.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	// We need to import libp2p's libraries that we use in this project.
-	// In order to work, these libraries need to be rewritten by gx-go.
 	host "github.com/libp2p/go-libp2p-host"
 	inet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"

--- a/multipro/README.md
+++ b/multipro/README.md
@@ -1,36 +1,36 @@
 # Protocol Multiplexing using rpc-style multicodecs, protobufs with libp2p
 
-This examples shows how to use multicodecs (i.e. protobufs) to encode and transmit information between LibP2P hosts using LibP2P Streams.
+This example shows how to use multicodecs (i.e. protobufs) to encode and transmit information between libp2p hosts using libp2p Streams.
 Multicodecs present a common interface, making it very easy to swap the codec implementation if needed.
 This example expects that you area already familiar with the [echo example](https://github.com/libp2p/go-libp2p/tree/master/examples/echo).
 
 ## Build
 
-From `go-libp2p-examples` base folder:
+From the `go-libp2p-examples` directory run the following:
 
-```
+```sh
 > make deps
-> go build ./multipro
+> cd multipro/
+> go build
 ```
 
 ## Usage
 
 ```sh
 > ./multipro
-
 ```
 
 ## Details
 
-The example creates two LibP2P Hosts supporting 2 protocols: ping and echo.
+The example creates two libp2p Hosts supporting 2 protocols: ping and echo.
 
-Each protocol consists RPC-style requests and responses and each request and response is a typed protobufs message (and a go data object).
+Each protocol consists of RPC-style requests and responses and each request and response is a typed protobufs message (and a go data object).
 
-This is a different pattern then defining a whole p2p protocol as one protobuf message with lots of optional fields (as can be observed in various p2p-lib protocols using protobufs such as dht).
+This is a different pattern than defining a whole p2p protocol as one protobuf message with lots of optional fields (as can be observed in various p2p-lib protocols using protobufs such as dht).
 
 The example shows how to match async received responses with their requests. This is useful when processing a response requires access to the request data.
 
-The idea is to use lib-p2p protocol multiplexing on a per-message basis.
+The idea is to use libp2p protocol multiplexing on a per-message basis.
 
 ### Features
 1. 2 fully implemented protocols using an RPC-like request-response pattern - Ping and Echo
@@ -41,5 +41,3 @@ The idea is to use lib-p2p protocol multiplexing on a per-message basis.
 
 ## Author
 @avive
-
-

--- a/protocol-multiplexing-with-multicodecs/README.md
+++ b/protocol-multiplexing-with-multicodecs/README.md
@@ -1,8 +1,6 @@
-
-
 # Protocol Multiplexing using multicodecs with libp2p
 
-This examples shows how to use multicodecs (i.e. json) to encode and transmit information between LibP2P hosts using LibP2P Streams.
+This example shows how to use multicodecs (i.e. json) to encode and transmit information between libp2p hosts using libp2p Streams.
 
 Multicodecs present a common interface, making it very easy to swap the codec implementation if needed.
 
@@ -10,23 +8,23 @@ This example expects that you area already familiar with the [echo example](http
 
 ## Build
 
-From `go-libp2p-examples` base folder:
+From the `go-libp2p-examples` directory run the following:
 
 ```
 > make deps
-> go build -o multicodecs ./protocol-multiplexing-with-multicodecs
+> cd protocol-multiplexing-with-multicodecs/
+> go build -o multicodecs
 ```
 
 ## Usage
 
 ```
 > ./multicodecs
-
 ```
 
 ## Details
 
-The example creates two LibP2P Hosts. Host1 opens a stream to Host2. Host2 has an `StreamHandler` to deal with the incoming stream. This is covered in the `echo` example.
+The example creates two libp2p Hosts. Host1 opens a stream to Host2. Host2 has a `StreamHandler` to deal with the incoming stream. This is covered in the `echo` example.
 
 Both hosts simulate a conversation. But rather than sending raw messages on the stream, each message in the conversation is encoded under a `json` object (using the `json` multicodec). For example:
 


### PR DESCRIPTION
Clarify that gx is not needed to run the examples and fix small grammar
errors in READMEs.

Fixes https://github.com/libp2p/go-libp2p-examples/issues/31