### PR TITLE
Update docs with consolidated types.

### DIFF
--- a/libp2p-host/README.md
+++ b/libp2p-host/README.md
@@ -12,8 +12,8 @@ import (
 	"crypto/rand"
 	"fmt"
 
-	libp2p "github.com/libp2p/go-libp2p"
-	crypto "github.com/libp2p/go-libp2p-crypto"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/crypto"
 )
 
 


### PR DESCRIPTION
The imports in the example work but `github.com/libp2p/go-libp2p-crypto` is deprecated