### PR TITLE
upgrade required kad-dht version to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/libp2p/go-libp2p-circuit v0.1.0
 	github.com/libp2p/go-libp2p-core v0.0.1
 	github.com/libp2p/go-libp2p-discovery v0.1.0
-	github.com/libp2p/go-libp2p-kad-dht v0.1.0
+	github.com/libp2p/go-libp2p-kad-dht v0.2.1
 	github.com/libp2p/go-libp2p-mplex v0.2.1
 	github.com/libp2p/go-libp2p-pubsub v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-secio v0.1.0


### PR DESCRIPTION
lower version of kad-dht depends on "golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522",which when build binarytarget makes deps mistake:
 "golang.org/x/xerrors@v0.0.0-20190513163551-3ee3066db522/adaptor_go1_13.go:16:14: undefined: errors.Frame ",
"golang.org/x/xerrors@v0.0.0-20190513163551-3ee3066db522/format_go1_13.go:12:18: undefined:errors.Formatter"