### PR TITLE
http-proxy: simplify code & improve README

### DIFF
--- a/http-proxy/README.md
+++ b/http-proxy/README.md
@@ -54,6 +54,12 @@ proxy listening on  127.0.0.1:9900
 As you can see, the proxy prints the listening address `127.0.0.1:9900`. You can now use this address as a proxy, for example with `curl`:
 
 ```
-> curl -x "127.0.0.1:9900" "http://ipfs.io/ipfs/QmfUX75pGRBRDnjeoMkQzuQczuCup2aYbeLxz5NzeSu9G6"
-it works!
+> curl -x "127.0.0.1:9900" "http://ipfs.io/ipfs/Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z"
+Hello World!
+```
+
+For `https` URLs, you should specify the port without the `https` schema. The remote peer will resolve appropiatelly:
+```
+> curl -x "127.0.0.1:9900" "ipfs.io:443/ipfs/Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z"
+Hello World!
 ```

--- a/http-proxy/proxy.go
+++ b/http-proxy/proxy.go
@@ -102,8 +102,6 @@ func streamHandler(stream network.Stream) {
 	hp := strings.Split(req.Host, ":")
 	if len(hp) > 1 && hp[1] == "443" {
 		req.URL.Scheme = "https"
-	} else {
-		req.URL.Scheme = "http"
 	}
 	req.URL.Host = req.Host
 
@@ -213,8 +211,7 @@ func addAddrToPeerstore(h host.Host, addr string) peer.ID {
 
 	// Decapsulate the /ipfs/<peerID> part from the target
 	// /ip4/<a.b.c.d>/ipfs/<peer> becomes /ip4/<a.b.c.d>
-	targetPeerAddr, _ := ma.NewMultiaddr(
-		fmt.Sprintf("/ipfs/%s", peer.IDB58Encode(peerid)))
+	targetPeerAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", pid))
 	targetAddr := ipfsaddr.Decapsulate(targetPeerAddr)
 
 	// We have a peer ID and a targetAddr so we add


### PR DESCRIPTION
Code changes:
* Avoid re-encoding to Base58 since we already have it encoded before.
* Avoid else case which already is the default value some lines before.

Readme:
* Changed the CID example since didn't resolve for me for a more reliable known "Hello World" CID.
* Added further comment about accessing HTTPS since may not be trivial at first.
