### PR TITLE
Avoid confusion of definition between peers and remove stream handler for local peer  

### DIFF
--- a/http-proxy/proxy.go
+++ b/http-proxy/proxy.go
@@ -63,7 +63,7 @@ func NewProxyService(h host.Host, proxyAddr ma.Multiaddr, dest peer.ID) *ProxySe
 	// ps := "Proxy"
 	// if len(dest) == 0 {
 	// 	h.SetStreamHandler(Protocol, streamHandler)
-	// 	ps = "Remote Peer" 
+	// 	ps = "Remote Peer"
 	// }
 
 	// fmt.Printf("%s server is ready", ps)

--- a/http-proxy/proxy.go
+++ b/http-proxy/proxy.go
@@ -66,7 +66,7 @@ func NewProxyService(h host.Host, proxyAddr ma.Multiaddr, dest peer.ID) *ProxySe
 		ps = "Remote Peer" 
 	}
 
-	fmt.Printf("%s server is rfeady", ps)
+	fmt.Printf("%s server is ready", ps)
 	fmt.Println("libp2p-peer addresses:")
 	for _, a := range h.Addrs() {
 		fmt.Printf("%s/ipfs/%s\n", a, peer.IDB58Encode(h.ID()))

--- a/http-proxy/proxy.go
+++ b/http-proxy/proxy.go
@@ -60,13 +60,16 @@ func NewProxyService(h host.Host, proxyAddr ma.Multiaddr, dest peer.ID) *ProxySe
 	// We let our host know that it needs to handle streams tagged with the
 	// protocol id that we have defined, and then handle them to
 	// our own streamHandling function.
-	ps := "Proxy"
-	if len(dest) == 0 {
-		h.SetStreamHandler(Protocol, streamHandler)
-		ps = "Remote Peer" 
-	}
+	// ps := "Proxy"
+	// if len(dest) == 0 {
+	// 	h.SetStreamHandler(Protocol, streamHandler)
+	// 	ps = "Remote Peer" 
+	// }
 
-	fmt.Printf("%s server is ready", ps)
+	// fmt.Printf("%s server is ready", ps)
+
+	h.SetStreamHandler(Protocol, streamHandler)
+	fmt.Println("Proxy server is ready")
 	fmt.Println("libp2p-peer addresses:")
 	for _, a := range h.Addrs() {
 		fmt.Printf("%s/ipfs/%s\n", a, peer.IDB58Encode(h.ID()))

--- a/http-proxy/proxy.go
+++ b/http-proxy/proxy.go
@@ -60,9 +60,13 @@ func NewProxyService(h host.Host, proxyAddr ma.Multiaddr, dest peer.ID) *ProxySe
 	// We let our host know that it needs to handle streams tagged with the
 	// protocol id that we have defined, and then handle them to
 	// our own streamHandling function.
-	h.SetStreamHandler(Protocol, streamHandler)
+	ps := "Proxy"
+	if len(dest) == 0 {
+		h.SetStreamHandler(Protocol, streamHandler)
+		ps = "Remote Peer" 
+	}
 
-	fmt.Println("Proxy server is ready")
+	fmt.Printf("%s server is rfeady", ps)
 	fmt.Println("libp2p-peer addresses:")
 	for _, a := range h.Addrs() {
 		fmt.Printf("%s/ipfs/%s\n", a, peer.IDB58Encode(h.ID()))

--- a/http-proxy/proxy.go
+++ b/http-proxy/proxy.go
@@ -60,16 +60,13 @@ func NewProxyService(h host.Host, proxyAddr ma.Multiaddr, dest peer.ID) *ProxySe
 	// We let our host know that it needs to handle streams tagged with the
 	// protocol id that we have defined, and then handle them to
 	// our own streamHandling function.
-	// ps := "Proxy"
-	// if len(dest) == 0 {
-	// 	h.SetStreamHandler(Protocol, streamHandler)
-	// 	ps = "Remote Peer"
-	// }
+	ps := "Proxy"
+	if len(dest) == 0 {
+		h.SetStreamHandler(Protocol, streamHandler)
+		ps = "Remote Peer"
+	}
 
-	// fmt.Printf("%s server is ready", ps)
-
-	h.SetStreamHandler(Protocol, streamHandler)
-	fmt.Println("Proxy server is ready")
+	fmt.Printf("%s server is ready", ps)
 	fmt.Println("libp2p-peer addresses:")
 	for _, a := range h.Addrs() {
 		fmt.Printf("%s/ipfs/%s\n", a, peer.IDB58Encode(h.ID()))


### PR DESCRIPTION
Code fix:

- Avoid confusion between the event definition of definite http request processor and proxy service