### PR TITLE
Update host.go

### DIFF
--- a/libp2p-host/host.go
+++ b/libp2p-host/host.go
@@ -73,7 +73,7 @@ func main() {
 		libp2p.NATPortMap(),
 		// Let this host use the DHT to find other hosts
 		libp2p.Routing(func(h host.Host) (routing.PeerRouting, error) {
-			idht, err = dht.New(ctx, h)
+			idht, err = dht.New(ctx, h, dht.Mode(dht.ModeServer))
 			return idht, err
 		}),
 		// Let this host use relays and advertise itself on relays if


### PR DESCRIPTION
Recent changes break the DHT peer discovery when testing on local and private nets.
https://github.com/libp2p/go-libp2p-kad-dht/issues/569