### PR TITLE
fixed relay example

### DIFF
--- a/relay/main.go
+++ b/relay/main.go
@@ -18,7 +18,7 @@ func main() {
 	// of them.
 
 	// Tell the host to monitor for relays.
-	h1, err := libp2p.New(context.Background(), libp2p.EnableRelay(circuit.OptDiscovery))
+	h1, err := libp2p.New(context.Background(), libp2p.EnableRelay())
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ func main() {
 	fmt.Println("Just as we suspected")
 
 	// Creates a relay address
-	relayaddr, err := ma.NewMultiaddr("/p2p-circuit/ipfs/" + h3.ID().Pretty())
+	relayaddr, err := ma.NewMultiaddr("/p2p/" + h2.ID().Pretty() + "/p2p-circuit/p2p/" + h3.ID().Pretty())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- removed `circuit.OptDiscovery` since it's a no-opt now
- updated relay address to include relay node. (~Not sure how it worked
before~ edit: maybe it worked because `OptDiscovery` made h1 actively check peers who could relay the transport)